### PR TITLE
Fix license

### DIFF
--- a/com.katawa_shoujo.KatawaShoujo.appdata.xml
+++ b/com.katawa_shoujo.KatawaShoujo.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
 	<id>com.katawa_shoujo.KatawaShoujo</id>
-	<metadata_license>CC-BY-SA-3.0</metadata_license>
+	<metadata_license>CC BY-NC-ND 3.0</metadata_license>
 	<name>Katawa Shoujo</name>
 	<summary>A bishoujo-style visual novel</summary>
 	<description>


### PR DESCRIPTION
The correct license is CC BY-NC-ND 3.0 and not CC BY-NC-SA 3.0 as suggested before. 

This information is obtained from https://www.katawa-shoujo.com/about.php.