### PR TITLE
Fix game license

### DIFF
--- a/com.katawa_shoujo.KatawaShoujo.appdata.xml
+++ b/com.katawa_shoujo.KatawaShoujo.appdata.xml
@@ -24,7 +24,7 @@
 			</description>
 		</release>
 	</releases>
-	<project_license>CC BY-NC-ND 3.0</project_license>
+	<project_license>CC-BY-NC-ND-3.0</project_license>
 	<developer_name>Four Leaf Studios</developer_name>
 	<screenshots>
 		<screenshot>

--- a/com.katawa_shoujo.KatawaShoujo.appdata.xml
+++ b/com.katawa_shoujo.KatawaShoujo.appdata.xml
@@ -24,7 +24,7 @@
 			</description>
 		</release>
 	</releases>
-	<project_license>CC-BY-NC-SA-3.0</project_license>
+	<project_license>CC BY-NC-ND 3.0</project_license>
 	<developer_name>Four Leaf Studios</developer_name>
 	<screenshots>
 		<screenshot>


### PR DESCRIPTION
The correct license is CC BY-NC-ND 3.0 and not CC BY-NC-SA 3.0 as suggested before.

This information is obtained from https://www.katawa-shoujo.com/about.php.