### PR TITLE
Add wayland socket

### DIFF
--- a/com.katawa_shoujo.KatawaShoujo.yaml
+++ b/com.katawa_shoujo.KatawaShoujo.yaml
@@ -12,6 +12,7 @@ add-extensions:
 finish-args:
   - --share=ipc
   - --socket=x11
+  - --socket=wayland
   - --device=dri
   - --socket=pulseaudio
   - --persist=.renpy


### PR DESCRIPTION
Attempting to run the arm version of this on postmarketOS currently requires the wayland socket to be available or it will throw the error `wayland not available`


![image](https://user-images.githubusercontent.com/101351551/212784080-1a76af29-d66c-4943-8caa-f608448304c2.png)



Adding `--socket=wayland` allows it to run. Also tested in Pop OS 22.04 wayland and it seems to run by default in Xwayland just like before, so it seems no change on the desktop while making the phone version actually run. Pure wayland version does work well now with renpy 8, but there is no headerbar on the desktop in Gnome Wayland due to Gnome's lack of server side decorations so it seems best to leave it this way with Xwayland still preferred.

