### PR TITLE
EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "end-of-life": "This application is superceded by Katawa Shoujo: Re-Engineered."
+}

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-  "end-of-life": "This application is superceded by Katawa Shoujo: Re-Engineered."
+  "end-of-life": "This application is superseded by Katawa Shoujo: Re-Engineered."
 }


### PR DESCRIPTION
For all intents and purposes, [Katawa Shoujo: Re-Engineered](https://flathub.org/en/apps/sh.fhs.ksre) has superseded this one already. It's got all the things you need and none of the trouble with the obfuscated original release.