### PR TITLE
EOL-NG

### DIFF
--- a/com.katawa_shoujo.KatawaShoujo.appdata.xml
+++ b/com.katawa_shoujo.KatawaShoujo.appdata.xml
@@ -14,7 +14,7 @@
 		<category>AdventureGame</category>
 	</categories>
 	<url type="homepage">https://www.katawa-shoujo.com/</url>
-	<url type="faq">https://ks.renai.us/viewtopic.php?f=13&amp;t=4717</url>
+	<url type="faq">https://ks.fhs.sh/viewtopic.php?f=13&amp;t=4717</url>
 	<launchable type="desktop-id">com.katawa_shoujo.KatawaShoujo.desktop</launchable>
 	<releases>
 		<release version="1.3.1" date="2015-04-06">
@@ -28,22 +28,22 @@
 	<developer_name>Four Leaf Studios</developer_name>
 	<screenshots>
 		<screenshot>
-			<image type="source">https://dl.katawa-shoujo.com/pr/sample/screen/screen_1.jpg</image>
+			<image type="source">https://www.katawa-shoujo.com/img/screenshot/screen_1.webp</image>
 		</screenshot>
 		<screenshot>
-			<image type="source">https://dl.katawa-shoujo.com/pr/sample/screen/screen_2.jpg</image>
+			<image type="source">https://www.katawa-shoujo.com/img/screenshot/screen_2.webp</image>
 		</screenshot>
 		<screenshot>
-			<image type="source">https://dl.katawa-shoujo.com/pr/sample/screen/screen_3.jpg</image>
+			<image type="source">https://www.katawa-shoujo.com/img/screenshot/screen_3.webp</image>
+		</screenshot>
+		<screenshot>
+			<image type="source">https://www.katawa-shoujo.com/img/screenshot/screen_4.webp</image>
+		</screenshot>
+		<screenshot>
+			<image type="source">https://www.katawa-shoujo.com/img/screenshot/screen_5.webp</image>
 		</screenshot>
 		<screenshot type="default">
-			<image type="source">https://dl.katawa-shoujo.com/pr/sample/screen/screen_4.jpg</image>
-		</screenshot>
-		<screenshot>
-			<image type="source">https://dl.katawa-shoujo.com/pr/sample/screen/screen_5.jpg</image>
-		</screenshot>
-		<screenshot>
-			<image type="source">https://dl.katawa-shoujo.com/pr/sample/screen/screen_6.jpg</image>
+			<image type="source">https://www.katawa-shoujo.com/img/screenshot/screen_6.webp</image>
 		</screenshot>
 	</screenshots>
 	<update_contact>sakcheen+flathub_AT_gmail.com</update_contact>

--- a/com.katawa_shoujo.KatawaShoujo.yaml
+++ b/com.katawa_shoujo.KatawaShoujo.yaml
@@ -76,6 +76,8 @@ modules:
       - type: archive
         url: https://www.renpy.org/dl/8.0.3/renpy-8.0.3-source.tar.bz2
         sha256: f6c9279bc9ab53c0afb1d35dae01e2e9bdfca57a8553039e2360987881f189ac
+      - type: patch
+        path: renpy-8.0.3-version.patch
       - type: script
         commands:
           - python /app/share/renpy/renpy.py "$@"

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "end-of-life": "This application is superceded by Katawa Shoujo: Re-Engineered."
+}

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-  "end-of-life": "This application is superseded by Katawa Shoujo: Re-Engineered."
+  "end-of-life": "This application is superseded by Katawa Shoujo: Re-Engineered, however existing saves cannot be transfered.",
+  "end-of-life-rebase": "sh.fhs.ksre"
 }

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-  "end-of-life": "This application is superceded by Katawa Shoujo: Re-Engineered."
+  "end-of-life": "This application is superseded by Katawa Shoujo: Re-Engineered."
 }

--- a/python3-modules.yaml
+++ b/python3-modules.yaml
@@ -9,17 +9,101 @@ modules:
     --prefix=${FLATPAK_DEST} "future" --no-build-isolation
   sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/8f/2e/cf6accf7415237d6faeeebdc7832023c90e0282aa16fd3263db0eb4715ec/future-0.18.3.tar.gz
-    sha256: 34a17436ed1e96697a86f9de3d15a3b0be01d8bc8de9c1dffd59fb8234ed5307
-- name: python3-typing
+    url: https://files.pythonhosted.org/packages/a7/b2/4140c69c6a66432916b26158687e821ba631a4c9273c474343badf84d3ba/future-1.0.0.tar.gz
+    sha256: bd2968309307861edae1458a4f8a4f3598c03be43b97521076aebf5d94c07b05
+- name: python3-flit-core  # Needed by idna, pathspec
   buildsystem: simple
   build-commands:
   - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-    --prefix=${FLATPAK_DEST} "typing" --no-build-isolation
+    --prefix=${FLATPAK_DEST} "flit-core" --no-build-isolation
   sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/05/d9/6eebe19d46bd05360c9a9aae822e67a80f9242aabbfc58b641b957546607/typing-3.7.4.3.tar.gz
-    sha256: 1187fb9c82fd670d10aa07bbb6cfcfe4bdda42d6fab8d5134f04e8c4d0b71cc9
+    url: https://files.pythonhosted.org/packages/69/59/b6fc2188dfc7ea4f936cd12b49d707f66a1cb7a1d2c16172963534db741b/flit_core-3.12.0.tar.gz
+    sha256: 18f63100d6f94385c6ed57a72073443e1a71a4acb4339491615d0f16d6ff01b2
+- name: python3-packaging
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+    --prefix=${FLATPAK_DEST} "packaging" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz
+    sha256: d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f
+- name: python3-tomli  # Needed by setuptools-scm on Python 3.10-
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+    --prefix=${FLATPAK_DEST} "tomli" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/82/30/31573e9457673ab10aa432461bee537ce6cef177667deca369efb79df071/tomli-2.4.0.tar.gz
+    sha256: aa89c3f6c277dd275d8e243ad24f3b5e701491a860d5121f2cdd399fbb31fc9c
+- name: python3-setuptools-scm  # Needed by pluggy
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+    --prefix=${FLATPAK_DEST} "setuptools-scm" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/7b/b1/19587742aad604f1988a8a362e660e8c3ac03adccdb71c96d86526e5eb62/setuptools_scm-9.2.2.tar.gz
+    sha256: 1c674ab4665686a0887d7e24c03ab25f24201c213e82ea689d2f3e169ef7ef57
+- name: python3-pathspec  # Needed by hatchling
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+    --prefix=${FLATPAK_DEST} "pathspec" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/4c/b2/bb8e495d5262bfec41ab5cb18f522f1012933347fb5d9e62452d446baca2/pathspec-1.0.3.tar.gz
+    sha256: bac5cf97ae2c2876e2d25ebb15078eb04d76e4b98921ee31c6f85ade8b59444d
+- name: python3-pluggy  # Needed by hatchling
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+    --prefix=${FLATPAK_DEST} "pluggy" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz
+    sha256: 7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3
+- name: python3-calver  # Needed by trove-classifiers
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+    --prefix=${FLATPAK_DEST} "calver" --no-build-isolation
+  sources:
+#  - type: file
+#    url: https://files.pythonhosted.org/packages/4a/96/0c57e3e228ffc54074867406b659b197678674f1f0bf600d114965289834/calver-2025.10.20.tar.gz
+#    sha256: c98b376c2424642224d456b2f70c51402343e008c63d204634665e1a2a2835f5
+  - type: file
+    url: https://files.pythonhosted.org/packages/b5/00/96cbed7c019c49ee04b8a08357a981983db7698ae6de402e57097cefc9ad/calver-2022.6.26.tar.gz
+    sha256: e05493a3b17517ef1748fbe610da11f10485faa7c416b9d33fd4a52d74894f8b
+- name: python3-trove-classifiers  # Needed by hatchling
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+    --prefix=${FLATPAK_DEST} "trove-classifiers" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/d8/43/7935f8ea93fcb6680bc10a6fdbf534075c198eeead59150dd5ed68449642/trove_classifiers-2026.1.14.14.tar.gz
+    sha256: 00492545a1402b09d4858605ba190ea33243d361e2b01c9c296ce06b5c3325f3
+- name: python3-hatchling  # Needed by urllib3
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+    --prefix=${FLATPAK_DEST} "hatchling" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/0b/8e/e480359492affde4119a131da729dd26da742c2c9b604dff74836e47eef9/hatchling-1.28.0.tar.gz
+    sha256: 4d50b02aece6892b8cd0b3ce6c82cb218594d3ec5836dbde75bf41a21ab004c8
+- name: python3-hatch-vcs  # Needed by urllib3
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+    --prefix=${FLATPAK_DEST} "hatch-vcs" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/6b/b0/4cc743d38adbee9d57d786fa496ed1daadb17e48589b6da8fa55717a0746/hatch_vcs-0.5.0.tar.gz
+    sha256: 0395fa126940340215090c344a2bf4e2a77bcbe7daab16f41b37b98c95809ff9
 - name: python3-pefile
   buildsystem: simple
   build-commands:
@@ -27,11 +111,8 @@ modules:
     --prefix=${FLATPAK_DEST} "pefile" --no-build-isolation
   sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/8f/2e/cf6accf7415237d6faeeebdc7832023c90e0282aa16fd3263db0eb4715ec/future-0.18.3.tar.gz
-    sha256: 34a17436ed1e96697a86f9de3d15a3b0be01d8bc8de9c1dffd59fb8234ed5307
-  - type: file
-    url: https://files.pythonhosted.org/packages/48/30/4559d06bad5bb627733dac1ef28c34f5e35f1461247ba63e5f6366901277/pefile-2022.5.30.tar.gz
-    sha256: a5488a3dd1fd021ce33f969780b88fe0f7eebb76eb20996d7318f307612a045b
+    url: https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz
+    sha256: 3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632
 - name: python3-requests
   buildsystem: simple
   build-commands:
@@ -39,20 +120,20 @@ modules:
     --prefix=${FLATPAK_DEST} "requests" --no-build-isolation
   sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/71/4c/3db2b8021bd6f2f0ceb0e088d6b2d49147671f25832fb17970e9b583d742/certifi-2022.12.7-py3-none-any.whl
-    sha256: 4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18
+    url: https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz
+    sha256: ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120
   - type: file
-    url: https://files.pythonhosted.org/packages/96/d7/1675d9089a1f4677df5eb29c3f8b064aa1e70c1251a0a8a127803158942d/charset-normalizer-3.0.1.tar.gz
-    sha256: ebea339af930f8ca5d7a699b921106c6e29c617fe9606fa7baa043c1cdae326f
+    url: https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz
+    sha256: 94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a
   - type: file
-    url: https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl
-    sha256: 90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
+    url: https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz
+    sha256: 795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902
   - type: file
-    url: https://files.pythonhosted.org/packages/d2/f4/274d1dbe96b41cf4e0efb70cbced278ffd61b5c7bb70338b62af94ccb25b/requests-2.28.2-py3-none-any.whl
-    sha256: 64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa
+    url: https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz
+    sha256: dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf
   - type: file
-    url: https://files.pythonhosted.org/packages/fe/ca/466766e20b767ddb9b951202542310cba37ea5f2d792dae7589f1741af58/urllib3-1.26.14-py2.py3-none-any.whl
-    sha256: 75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1
+    url: https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz
+    sha256: 1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed
 - name: python3-ecdsa
   buildsystem: simple
   build-commands:
@@ -60,5 +141,8 @@ modules:
     --prefix=${FLATPAK_DEST} "ecdsa" --no-build-isolation
   sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/09/d4/4f05f5d16a4863b30ba96c23b23e942da8889abfa1cdbabf2a0df12a4532/ecdsa-0.18.0-py2.py3-none-any.whl
-    sha256: 80600258e7ed2f16b9aa1d7c295bd70194109ad5a30fdee0eaeefef1d4c559dd
+    url: https://files.pythonhosted.org/packages/c0/1f/924e3caae75f471eae4b26bd13b698f6af2c44279f67af317439c2f4c46a/ecdsa-0.19.1.tar.gz
+    sha256: 478cba7b62555866fcb3bb3fe985e06decbdb68ef55713c4e5ab98c57d508e61
+  - type: file
+    url: https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz
+    sha256: ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81

--- a/renpy-8.0.3-version.patch
+++ b/renpy-8.0.3-version.patch
@@ -1,0 +1,8 @@
+--- a/module/setup.py.bak	2026-01-16 23:52:55.916156921 +0100
++++ b/module/setup.py	2026-01-16 23:53:39.503196467 +0100
+@@ -225,4 +225,4 @@
+ 
+ import renpy
+ 
+-setuplib.setup("Ren'Py", renpy.version[7:]) # @UndefinedVariable
++setuplib.setup("Ren'Py", renpy.version[7:].removesuffix("u")) # @UndefinedVariable


### PR DESCRIPTION
Hopefully working version of #19.

Notes that KSRE is not compatible with KS saves and updates dependencies to the maximum extent possible. (RenPy 8.0.3 doesn’t compile against Python 3.11+, so still using deprecated runtime for the EOL release.)